### PR TITLE
updated node configuration to major version 6

### DIFF
--- a/libexec/bootstrapper-install-mac
+++ b/libexec/bootstrapper-install-mac
@@ -336,7 +336,9 @@ find_latest_node_lts() {
     jq '[.[].version | match("[0-9]*[02468].[0-9]+.[0-9]+"; "g")] | .[0].string' | \
     sed -e 's/^"//'  -e 's/"$//'
 }
-node_version="$(find_latest_node_lts)"
+
+
+node_version="6"
 mkdir -p "$HOME/.nvm"
 
 # shellcheck disable=SC2016
@@ -347,9 +349,8 @@ append_to_zshrc 'source $(brew --prefix nvm)/nvm.sh' 1
 
 export NVM_DIR="$HOME/.nvm"
 . "$(brew --prefix nvm)/nvm.sh"
-if ! nvm ls "$node_version" | grep -Fq "$node_version"; then
-  nvm install "$node_version"
-fi
+
+nvm install "$node_version"
 
 nvm alias default "$node_version"
 


### PR DESCRIPTION
also removed LTS lookup

If hard-coding a specific major version smells wrong, we may also want to consider using "stable" instead.
