### PR TITLE
Upgrade bash if necessary

### DIFF
--- a/libexec/bootstrapper-install-mac
+++ b/libexec/bootstrapper-install-mac
@@ -240,6 +240,7 @@ brew_install_or_upgrade 'coreutils'
 append_to_zshrc 'export PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH"'
 export PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH"
 
+brew_install_or_upgrade 'bash'
 brew_install_or_upgrade 'binutils'
 brew_install_or_upgrade 'diffutils'
 brew_install_or_upgrade 'ed' --with-default-names


### PR DESCRIPTION
Ran into an issue where readline install will fail if an older version of bash is being run (see https://github.com/Homebrew/homebrew-core/issues/5799). A simple `brew upgrade bash` fixed it. This is to have the bootstrapper upgrade it if necessary to prevent others from running into it if they have an older bash as well on Mac.