### PR TITLE
Adds homebrew High Sierra support

### DIFF
--- a/libexec/bootstrapper-install-mac
+++ b/libexec/bootstrapper-install-mac
@@ -194,7 +194,7 @@ esac
 
 fancy_echo "Preparing /usr/local ..."
 if [ -d "/usr/local" ]; then
-  sudo chown -R "$(whoami)":admin /usr/local
+  sudo chown -R $(whoami) $(brew --prefix)/*
 else
   sudo mkdir /usr/local
   sudo chflags norestricted /usr/local


### PR DESCRIPTION
With High Sierra (latest Mac OSX), the /usr/local folder can no
longer be directly chown'ed. Instead, all child directories need to
be directly chowned via the brew prefix. This change is taken
directly from the issue on Homebrew project:
https://github.com/Homebrew/brew/issues/3228