### PR TITLE
fix homebrew dupes deprecation

### DIFF
--- a/libexec/bootstrapper-install-mac
+++ b/libexec/bootstrapper-install-mac
@@ -228,7 +228,7 @@ fi
 
 fancy_echo "Updating Homebrew formulae ..."
 brew_tap 'thoughtbot/formulae'
-brew_tap 'homebrew/dupes'
+brew_tap 'homebrew/core'
 brew_tap 'concur/formulae'
 
 brew update


### PR DESCRIPTION
Homebrew/dupes is deprecated and fails to run